### PR TITLE
Fix/improve cooldown insuff energy popup

### DIFF
--- a/NM3216 Project 2.yyp
+++ b/NM3216 Project 2.yyp
@@ -134,6 +134,7 @@
     {"id":{"name":"oFat_Level2_Dead","path":"objects/oFat_Level2_Dead/oFat_Level2_Dead.yy",},"order":3,},
     {"id":{"name":"oHealthIcon","path":"objects/oHealthIcon/oHealthIcon.yy",},"order":4,},
     {"id":{"name":"sEnemy_Dead","path":"sprites/sEnemy_Dead/sEnemy_Dead.yy",},"order":1,},
+    {"id":{"name":"get_player_gui_coords","path":"scripts/get_player_gui_coords/get_player_gui_coords.yy",},"order":17,},
     {"id":{"name":"enemy_movement","path":"scripts/enemy_movement/enemy_movement.yy",},"order":10,},
     {"id":{"name":"fInstructions","path":"fonts/fInstructions/fInstructions.yy",},"order":3,},
     {"id":{"name":"sPlayer","path":"sprites/sPlayer/sPlayer.yy",},"order":0,},

--- a/objects/oForkButton/Draw_64.gml
+++ b/objects/oForkButton/Draw_64.gml
@@ -15,6 +15,9 @@ if (oPlayer.alarm[1] != -1) {
 }
 
 // show feedback for insufficient energy
-if (oPlayer.key_attack_fork && oPlayer.can_fork && global.energy < oPlayer.fork_energy) {
-	draw_gui_message_box(x - 30, y - 100, "Insufficient Energy!", fGeneral, make_color_rgb(235, 42, 42));
+if (oPlayer.key_attack_fork && global.energy < oPlayer.fork_energy && oPlayer.state != PLAYERSTATE.ATTACK_FORK) {
+	playerGuiCoords = get_player_gui_coords();
+	xx = playerGuiCoords[0];
+	yy = playerGuiCoords[1];
+	draw_gui_message_box(xx, yy, "Needs 2 Energy!", fGeneral, make_color_rgb(235, 42, 42));
 }

--- a/objects/oKnifeButton/Draw_64.gml
+++ b/objects/oKnifeButton/Draw_64.gml
@@ -15,6 +15,9 @@ if (oPlayer.alarm[2] != -1) {
 }
 
 // show feedback for insufficient energy
-if (oPlayer.key_attack_knife && oPlayer.can_knife && global.energy < oPlayer.knife_energy) {
-	draw_gui_message_box(x - 30, y - 100, "Insufficient\nEnergy!", fGeneral, make_color_rgb(235, 42, 42));
+if (oPlayer.key_attack_knife && global.energy < oPlayer.knife_energy && oPlayer.state != PLAYERSTATE.ATTACK_KNIFE) {
+	playerGuiCoords = get_player_gui_coords();
+	xx = playerGuiCoords[0];
+	yy = playerGuiCoords[1];
+	draw_gui_message_box(xx, yy, "Needs 3 Energy!", fGeneral, make_color_rgb(235, 42, 42));
 }

--- a/objects/oPlayer/Draw_64.gml
+++ b/objects/oPlayer/Draw_64.gml
@@ -1,10 +1,9 @@
 /// @description Draw tutorial messages
 
 // calculate position of GUI element to be above player
-display_scalex = display_get_gui_width()/(halfViewWidth*2);
-display_scaley = display_get_gui_height()/(halfViewHeight*2);
-xx = (x - camera_get_view_x(view_camera[0])) * display_scalex;
-yy = (y - camera_get_view_y(view_camera[0])) * display_scaley;
+playerGuiCoords = get_player_gui_coords();
+xx = playerGuiCoords[0];
+yy = playerGuiCoords[1];
 
 if (global.in_tutorial) {
 	textToDisplay = "";

--- a/scripts/get_player_gui_coords/get_player_gui_coords.gml
+++ b/scripts/get_player_gui_coords/get_player_gui_coords.gml
@@ -1,0 +1,9 @@
+// translates player's room coords to GUI coords
+// so you can display things relative to the player in the GUI layer
+function get_player_gui_coords(){
+	display_scalex = display_get_gui_width()/(oPlayer.halfViewWidth*2);
+	display_scaley = display_get_gui_height()/(oPlayer.halfViewHeight*2);
+	xx = (oPlayer.x - camera_get_view_x(view_camera[0])) * display_scalex;
+	yy = (oPlayer.y - camera_get_view_y(view_camera[0])) * display_scaley;
+	return [xx, yy];
+}

--- a/scripts/get_player_gui_coords/get_player_gui_coords.yy
+++ b/scripts/get_player_gui_coords/get_player_gui_coords.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Scripts",
+    "path": "folders/Scripts.yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "get_player_gui_coords",
+  "tags": [],
+  "resourceType": "GMScript",
+}


### PR DESCRIPTION
Improvement on #36 
- Insufficient energy feedback msg was mildly buggy, fixed condition when it appears
- Changed msg to "Needs 2 Energy!" for fork and "Needs 3 Energy!" for knife, might be even clearer to the player so they know how much they need
- Placed the msg above player's head too, so better focus of attention. Hopefully it won't get too cluttered around the player later
- Abstracted out get_player_gui_coords script, which gets the player's coordinates in the GUI layer, which allows us to position things relative to the player in Draw GUI events